### PR TITLE
single function as children should keep it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,4 +103,7 @@ dist
 # TernJS port file
 .tern-port
 
+# vscode config
+.vscode
+
 dist

--- a/packages/babel-plugin-jsx/test/index.test.js
+++ b/packages/babel-plugin-jsx/test/index.test.js
@@ -306,6 +306,40 @@ describe('slots', () => {
 
     expect(wrapper.html()).toBe('<div>foo</div>');
   });
+
+  test('pass only single function as children should keep it', () => {
+    const A = (_, { slots }) => (
+      <div>
+        {slots.default()}
+      </div>
+    );
+
+    const wrapper = mount({
+      setup() {
+        return () => <A>{() => 'foo'}</A>;
+      },
+    });
+
+    expect(wrapper.html()).toBe('<div>foo</div>');
+  });
+
+  test('pass only single variable of function should keep it', () => {
+    const A = (_, { slots }) => (
+      <div>
+        {slots.default()}
+      </div>
+    );
+
+    const renderA = () => 'foo';
+
+    const wrapper = mount({
+      setup() {
+        return () => <A>{renderA}</A>;
+      },
+    });
+
+    expect(wrapper.html()).toBe('<div>foo</div>');
+  });
 });
 
 describe('PatchFlags', () => {


### PR DESCRIPTION
When we write this code:

```js
<Comp>{() => 'foo'}</Comp>
```

we should not wrapper the expressionContainer into another functionExpression, this PR implement it.

I PR this for a preview of implementation. 

There is still a TODO left, because I'm not very familiar with babel APi, I am requiring a early preview for my code. 

Please give me some feed back